### PR TITLE
Add NanumMyeongjo font option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
    - PaddleOCR
 
 - Font recognition engines:
-   - /
+  - simple (TimesNewRoman)
+  - nanum (NanumMyeongjo)
 
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,4 +11,4 @@ ocr:
   device: 'cuda'
 
 font:
-  type: 'simple'
+  type: 'simple'  # use 'nanum' for NanumMyeongjo

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -33,5 +33,10 @@ def load_font_engine(cfg: dict):
         engine = SimpleFont()
         engine.init(cfg)
         return engine
-    
-    raise("unknown ocr engine")
+    if cfg['type'] == 'nanum':
+        from .font.nanum import NanumFont
+        engine = NanumFont()
+        engine.init(cfg)
+        return engine
+
+    raise("unknown font engine")

--- a/modules/font/nanum.py
+++ b/modules/font/nanum.py
@@ -1,0 +1,43 @@
+import numpy as np
+from tqdm import tqdm
+from .base import FontBase
+
+class NanumFont(FontBase):
+    FONT_SIZE = 29
+
+    def init(self, cfg: dict):
+        self.cfg = cfg
+
+    def get_all_fonts(self, layout):
+        for i, line in tqdm(enumerate(layout)):
+            if line.type in ["text", "list", "title"]:
+                image = line.image
+                family, size, ygain = self.get_font_info(image, line.line_cnt)
+                line.font = {"family": family, "size": size, "ygain": ygain}
+        return layout
+
+    def get_font_info(self, image: np.ndarray, line_cnt: int = 1):
+        if image.ndim == 3:
+            height, width, _ = image.shape
+        else:
+            height, width = image.shape
+
+        if not line_cnt or line_cnt <= 0:
+            line_cnt = 1
+
+        font_size = height / line_cnt
+        print(f"width: {width}, height: {height}, fs: {font_size}")
+        if font_size > 46:
+            font_size = self.FONT_SIZE + 6
+            ygain = 40
+        elif font_size > 31:
+            font_size = self.FONT_SIZE
+            ygain = 33
+        elif font_size > 28.5:
+            font_size = self.FONT_SIZE - 3
+            ygain = 30
+        else:
+            font_size = self.FONT_SIZE - 6
+            ygain = 22
+
+        return 'NanumMyeongjo.ttf', font_size, ygain


### PR DESCRIPTION
## Summary
- implement `NanumFont` that returns NanumMyeongjo font data
- support `nanum` font engine in modules loader
- document font engines in README
- mention how to enable Nanum font in config

## Testing
- `python3 -m py_compile modules/font/nanum.py modules/__init__.py`