### PR TITLE
Change default target language to Korean

### DIFF
--- a/modules/translate/openai_gpt.py
+++ b/modules/translate/openai_gpt.py
@@ -101,7 +101,7 @@ class TranslateOpenAIGPT(TranslateBase):
     def get_languages(self):
         return langs
 
-    def translate(self, text: str, from_lang='ENGLISH', to_lang='SLOVENIAN') -> str:
+    def translate(self, text: str, from_lang='ENGLISH', to_lang='KOREAN') -> str:
         response = self.client.chat.completions.create(
             model='gpt-4-1106-preview',
             temperature=0.2,

--- a/utils/gui.py
+++ b/utils/gui.py
@@ -43,7 +43,7 @@ def create_gradio_app(langs):
 
             
             from_lang = gr.Dropdown(label='from language', choices=langs, value="English")
-            to_lang = gr.Dropdown(label='to language', choices=langs, value="Slovenian")
+            to_lang = gr.Dropdown(label='to language', choices=langs, value="Korean")
             from_page = gr.Number(label='from page')
             to_page = gr.Number(label='to page')
             both = gr.Checkbox(label='render side by side', value=True)


### PR DESCRIPTION
## Summary
- use Korean as the default target language in Gradio UI
- default to Korean for OpenAI translation function

## Testing
- `pytest -q`