### PR TITLE
Update defaults to OpenAI GPT-4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 - translate PDF files while preserving layout
 
 - translation engines:
-   - google translate (default)
-   - openAI (best)
+   - openAI (default)
+   - google translate
 
 - layout recognition engines:
    - UniLM DiT
@@ -36,9 +36,8 @@
    cd pdf_translator
 ```
 
-2. **Edit config.yaml and enter openai api key**
-change type to 'openai' and enter your key under openai_api_key
-if this is not changed translation engine will default to google translate
+2. **Edit config.yaml and enter your OpenAI API key**
+Enter your key under `openai_api_key`.
 
 
 ### docker installation

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 translator:
-  type: google_translate #openai
+  type: openai
+  model: gpt-4o
   openai_api_key: YOUR-KEY-GOES-HERE
 
 layout:

--- a/modules/translate/openai_gpt.py
+++ b/modules/translate/openai_gpt.py
@@ -97,13 +97,14 @@ langs = [
 class TranslateOpenAIGPT(TranslateBase):
     def init(self, cfg: dict):
         self.client = OpenAI(api_key=cfg['openai_api_key'])
+        self.model = cfg.get('model', 'gpt-4o')
 
     def get_languages(self):
         return langs
 
     def translate(self, text: str, from_lang='ENGLISH', to_lang='SLOVENIAN') -> str:
         response = self.client.chat.completions.create(
-            model='gpt-4-1106-preview',
+            model=self.model,
             temperature=0.2,
             messages=[
                 { 'role': 'system', 'content': system_prompt(from_lang, to_lang) },


### PR DESCRIPTION
## Summary
- set translator type to `openai` in config
- default to `gpt-4o` model
- make model configurable in `TranslateOpenAIGPT`
- update README to reflect OpenAI as default engine

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`