### PR TITLE
Fix model download location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,17 @@ PROJECT_DIRECTORY=$(shell pwd)
 MODEL_FILE=models/unilm/publaynet_dit-b_cascade.pth
 
 build:
-	mkdir -p models/unilm 
-	if [ ! -f $(MODEL_FILE) ]; then \
-		wget "https://huggingface.co/Sebas6k/DiT_weights/resolve/main/publaynet_dit-b_cascade.pth?download=true" -P models/unilm -O publaynet_dit-b_cascade.pth; \
-	fi
+        mkdir -p models/unilm
+        if [ ! -f $(MODEL_FILE) ]; then \
+                wget "https://huggingface.co/Sebas6k/DiT_weights/resolve/main/publaynet_dit-b_cascade.pth?download=true" -O models/unilm/publaynet_dit-b_cascade.pth; \
+        fi
 
 	docker build -t ${NAME}:${TAG} .
 
 get_models:
-	if [ ! -f $(MODEL_FILE) ]; then \
-		wget "https://huggingface.co/Sebas6k/DiT_weights/resolve/main/publaynet_dit-b_cascade.pth?download=true" -P models/unilm -O publaynet_dit-b_cascade.pth; \
-	fi
+        if [ ! -f $(MODEL_FILE) ]; then \
+                wget "https://huggingface.co/Sebas6k/DiT_weights/resolve/main/publaynet_dit-b_cascade.pth?download=true" -O models/unilm/publaynet_dit-b_cascade.pth; \
+        fi
 
 run:
 	docker run -it \


### PR DESCRIPTION
## Summary
- ensure `make get_models` stores the model under `models/unilm`

## Testing
- `make get_models` *(fails: No route to host)*