### PR TITLE
Fix text rendering cutoff

### DIFF
--- a/modules/font/nanum.py
+++ b/modules/font/nanum.py
@@ -1,5 +1,6 @@
 import numpy as np
 from tqdm import tqdm
+from PIL import ImageFont
 from utils import fw_fill
 from .base import FontBase
 
@@ -37,17 +38,24 @@ class NanumFont(FontBase):
         else:
             font_size = self.FONT_SIZE - 6
 
-        ygain = int(font_size * 1.15)
-
-        max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
-        processed = fw_fill(text, width=max_width_chars)
-        lines = len(processed.split("\n"))
-
-        while lines * ygain > height and font_size > 10:
-            font_size -= 1
+        while font_size > 10:
             ygain = int(font_size * 1.15)
             max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
             processed = fw_fill(text, width=max_width_chars)
-            lines = len(processed.split("\n"))
+            lines = processed.split("\n")
 
+            font = ImageFont.truetype("fonts/NanumMyeongjo.ttf", int(font_size))
+            max_line_width = 0
+            for l in lines:
+                bbox = font.getbbox(l)
+                line_width = bbox[2] - bbox[0]
+                if line_width > max_line_width:
+                    max_line_width = line_width
+
+            if len(lines) * ygain <= height and max_line_width <= width:
+                break
+
+            font_size -= 1
+
+        ygain = int(font_size * 1.15)
         return "NanumMyeongjo.ttf", int(font_size), int(ygain)

--- a/modules/font/simple.py
+++ b/modules/font/simple.py
@@ -1,5 +1,6 @@
 import numpy as np
 from tqdm import tqdm
+from PIL import ImageFont
 from utils import fw_fill
 from .base import FontBase
 
@@ -38,18 +39,25 @@ class SimpleFont(FontBase):
         else:
             font_size = self.FONT_SIZE - 6
 
-        ygain = int(font_size * 1.15)
-
-        max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
-        processed = fw_fill(text, width=max_width_chars)
-        lines = len(processed.split("\n"))
-
-        while lines * ygain > height and font_size > 10:
-            font_size -= 1
+        while font_size > 10:
             ygain = int(font_size * 1.15)
             max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
             processed = fw_fill(text, width=max_width_chars)
-            lines = len(processed.split("\n"))
+            lines = processed.split("\n")
 
+            font = ImageFont.truetype("fonts/TimesNewRoman.ttf", int(font_size))
+            max_line_width = 0
+            for l in lines:
+                bbox = font.getbbox(l)
+                line_width = bbox[2] - bbox[0]
+                if line_width > max_line_width:
+                    max_line_width = line_width
+
+            if len(lines) * ygain <= height and max_line_width <= width:
+                break
+
+            font_size -= 1
+
+        ygain = int(font_size * 1.15)
         return "TimesNewRoman.ttf", int(font_size), int(ygain)
                 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -36,10 +36,6 @@ def draw_text(draw, processed_text, current_fnt, font_size, width, ygain):
     """Draw text on an image without justifying spaces."""
 
     y = 0
-    lines = processed_text.split("\n")
-    indent_first = 40 if len(lines) > 1 else 0
-
-    for i, line in enumerate(lines):
-        x = indent_first if i == 0 else 0
-        draw.text((x, y), line, font=current_fnt, fill="black")
+    for line in processed_text.split("\n"):
+        draw.text((0, y), line, font=current_fnt, fill="black")
         y += ygain


### PR DESCRIPTION
## Summary
- refine font sizing logic to ensure text fits bounding box

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
