### PR TITLE
Fix text clipping by using actual font width

### DIFF
--- a/modules/font/nanum.py
+++ b/modules/font/nanum.py
@@ -1,6 +1,7 @@
 import numpy as np
 from tqdm import tqdm
-from utils import fw_fill
+from PIL import ImageFont
+from utils import fw_fill, average_char_width
 from .base import FontBase
 
 class NanumFont(FontBase):
@@ -39,14 +40,18 @@ class NanumFont(FontBase):
 
         ygain = int(font_size * 1.15)
 
-        max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
+        fnt = ImageFont.truetype('fonts/NanumMyeongjo.ttf', int(font_size))
+        char_w = average_char_width(fnt)
+        max_width_chars = max(1, int(width / char_w) - 1)
         processed = fw_fill(text, width=max_width_chars)
         lines = len(processed.split("\n"))
 
         while lines * ygain > height and font_size > 10:
             font_size -= 1
             ygain = int(font_size * 1.15)
-            max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
+            fnt = ImageFont.truetype('fonts/NanumMyeongjo.ttf', int(font_size))
+            char_w = average_char_width(fnt)
+            max_width_chars = max(1, int(width / char_w) - 1)
             processed = fw_fill(text, width=max_width_chars)
             lines = len(processed.split("\n"))
 

--- a/modules/font/simple.py
+++ b/modules/font/simple.py
@@ -1,6 +1,7 @@
 import numpy as np
 from tqdm import tqdm
-from utils import fw_fill
+from PIL import ImageFont
+from utils import fw_fill, average_char_width
 from .base import FontBase
 
 class SimpleFont(FontBase):
@@ -40,14 +41,18 @@ class SimpleFont(FontBase):
 
         ygain = int(font_size * 1.15)
 
-        max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
+        fnt = ImageFont.truetype('fonts/TimesNewRoman.ttf', int(font_size))
+        char_w = average_char_width(fnt)
+        max_width_chars = max(1, int(width / char_w) - 1)
         processed = fw_fill(text, width=max_width_chars)
         lines = len(processed.split("\n"))
 
         while lines * ygain > height and font_size > 10:
             font_size -= 1
             ygain = int(font_size * 1.15)
-            max_width_chars = max(1, int(width / (font_size / 2.4)) - 1)
+            fnt = ImageFont.truetype('fonts/TimesNewRoman.ttf', int(font_size))
+            char_w = average_char_width(fnt)
+            max_width_chars = max(1, int(width / char_w) - 1)
             processed = fw_fill(text, width=max_width_chars)
             lines = len(processed.split("\n"))
 

--- a/server.py
+++ b/server.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 import gradio as gr
 
 
-from utils import fw_fill, create_gradio_app, load_config, draw_text
+from utils import fw_fill, create_gradio_app, load_config, draw_text, average_char_width
 from modules import load_translator, load_layout_engine, load_ocr_engine, load_font_engine
 
 
@@ -222,14 +222,13 @@ class TranslateApi:
                     height = line.bbox[3] - line.bbox[1]
                     width = line.bbox[2] - line.bbox[0]
                     
+                    fnt = ImageFont.truetype('fonts/' + line.font['family'], line.font['size'])
+                    char_w = average_char_width(fnt)
                     # calculate text wrapping
                     processed_text = fw_fill(
                         line.translated_text,
-                        width=int((width) / ((line.font['size'])/2.4))
-                        - 1,
+                        width=max(1, int(width / char_w) - 1),
                     )
-
-                    fnt = ImageFont.truetype('fonts/' + line.font['family'], line.font['size']) 
                     
                     # create new image block with new text
                     new_block = Image.new("RGB", ( width, height ), color=(255, 255, 255))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,10 +3,24 @@ from .textwrap_local import fw_fill, fw_wrap
 from .ocr_model import OCRModel
 from .layout_model import LayoutAnalyzer
 from .gui import create_gradio_app
+from PIL import ImageFont
 
 import yaml
 
-__all__ = ["fw_fill", "fw_wrap", "OCRModel", "LayoutAnalyzer"]
+__all__ = ["fw_fill", "fw_wrap", "OCRModel", "LayoutAnalyzer", "average_char_width"]
+
+
+def average_char_width(font: ImageFont.FreeTypeFont) -> int:
+    """Return an estimated average character width for the given font."""
+    try:
+        bbox = font.getbbox("가")
+        width = bbox[2] - bbox[0]
+        if width > 0:
+            return width
+    except Exception:
+        pass
+    bbox = font.getbbox("A")
+    return bbox[2] - bbox[0]
 
 def load_config(base_config_path, override_config_path):
     with open(base_config_path, 'r') as base_file:


### PR DESCRIPTION
## Summary
- add `average_char_width` helper to compute width from fonts
- use `average_char_width` in font modules and server to calculate wrapping widths

## Testing
- `pytest -q`