### PR TITLE
Fix text width calculation

### DIFF
--- a/modules/font/nanum.py
+++ b/modules/font/nanum.py
@@ -1,6 +1,7 @@
 import numpy as np
 from tqdm import tqdm
 from PIL import ImageFont
+import math
 from utils import fw_fill, average_char_width
 from .base import FontBase
 
@@ -42,7 +43,7 @@ class NanumFont(FontBase):
 
         fnt = ImageFont.truetype('fonts/NanumMyeongjo.ttf', int(font_size))
         char_w = average_char_width(fnt)
-        max_width_chars = max(1, int(width / char_w))
+        max_width_chars = max(1, math.ceil(width / char_w))
         processed = fw_fill(text, width=max_width_chars)
         lines = len(processed.split("\n"))
 
@@ -51,7 +52,7 @@ class NanumFont(FontBase):
             ygain = int(font_size * 1.15)
             fnt = ImageFont.truetype('fonts/NanumMyeongjo.ttf', int(font_size))
             char_w = average_char_width(fnt)
-            max_width_chars = max(1, int(width / char_w))
+            max_width_chars = max(1, math.ceil(width / char_w))
             processed = fw_fill(text, width=max_width_chars)
             lines = len(processed.split("\n"))
 

--- a/modules/font/simple.py
+++ b/modules/font/simple.py
@@ -1,6 +1,7 @@
 import numpy as np
 from tqdm import tqdm
 from PIL import ImageFont
+import math
 from utils import fw_fill, average_char_width
 from .base import FontBase
 
@@ -43,7 +44,7 @@ class SimpleFont(FontBase):
 
         fnt = ImageFont.truetype('fonts/TimesNewRoman.ttf', int(font_size))
         char_w = average_char_width(fnt)
-        max_width_chars = max(1, int(width / char_w))
+        max_width_chars = max(1, math.ceil(width / char_w))
         processed = fw_fill(text, width=max_width_chars)
         lines = len(processed.split("\n"))
 
@@ -52,7 +53,7 @@ class SimpleFont(FontBase):
             ygain = int(font_size * 1.15)
             fnt = ImageFont.truetype('fonts/TimesNewRoman.ttf', int(font_size))
             char_w = average_char_width(fnt)
-            max_width_chars = max(1, int(width / char_w))
+            max_width_chars = max(1, math.ceil(width / char_w))
             processed = fw_fill(text, width=max_width_chars)
             lines = len(processed.split("\n"))
 

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+import math
 from typing import List, Tuple, Union
 import matplotlib.pyplot as plt
 import numpy as np
@@ -226,13 +227,13 @@ class TranslateApi:
 
                     height = line.bbox[3] - line.bbox[1]
                     width = line.bbox[2] - line.bbox[0]
-                    
+
                     fnt = ImageFont.truetype('fonts/' + line.font['family'], line.font['size'])
                     char_w = average_char_width(fnt)
-                    # calculate text wrapping
+                    # calculate text wrapping using all available width
                     processed_text = fw_fill(
                         line.translated_text,
-                        width=max(1, int(width / char_w)),
+                        width=max(1, math.ceil(width / char_w)),
                     )
                     
                     # create new image block with new text


### PR DESCRIPTION
## Summary
- use `math.ceil` to use available width when wrapping text
- add `math` imports in server and font modules

## Testing
- `python -m py_compile server.py modules/font/simple.py modules/font/nanum.py`
- `pytest -q`