### PR TITLE
Fix justification spacing for short lines

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -79,7 +79,14 @@ def draw_text(draw, processed_text, current_fnt, font_size, width, ygain):
             y += ygain
             continue
         line_text_width = sum(_text_width(current_fnt, w) for w in words)
-        space_slots = max(len(words) - 1, 1)
+
+        # Left-align short lines to avoid excessive spacing when justifying
+        if len(words) <= 2 or line_text_width / width < 0.6:
+            draw.text((0, y), " ".join(words), font=current_fnt, fill="black")
+            y += ygain
+            continue
+
+        space_slots = len(words) - 1
         total_space = max(width - line_text_width, 0)
         base_space = total_space // space_slots
         extra_space = total_space % space_slots


### PR DESCRIPTION
## Summary
- prevent overly-wide gaps in justified text by left-aligning short lines

## Testing
- `pytest -q`