### PR TITLE
Improve font scaling for high DPI

### DIFF
--- a/modules/font/nanum.py
+++ b/modules/font/nanum.py
@@ -12,7 +12,9 @@ class NanumFont(FontBase):
         self.cfg = cfg
         self.dpi = cfg.get('dpi', 200)
         self.base_font_size = cfg.get('base_size', self.BASE_FONT_SIZE)
-        self.FONT_SIZE = self.base_font_size * (self.dpi / 200)
+        # Scale the base font size with DPI.  The exponent makes fonts
+        # noticeably larger at high DPI values.
+        self.FONT_SIZE = self.base_font_size * (self.dpi / 200) ** 1.5
 
     def get_all_fonts(self, layout):
         for _, line in tqdm(enumerate(layout)):
@@ -33,7 +35,8 @@ class NanumFont(FontBase):
         line_cnt = line.line_cnt if line.line_cnt and line.line_cnt > 0 else 1
 
         font_size = height / line_cnt
-        step = 6 * (self.dpi / 200)
+        # Allow a wider range of font sizes for high DPI values
+        step = 6 * (self.dpi / 200) ** 1.5
         if font_size > self.FONT_SIZE + step:
             font_size = self.FONT_SIZE + step
         elif font_size > self.FONT_SIZE:

--- a/modules/font/simple.py
+++ b/modules/font/simple.py
@@ -12,7 +12,8 @@ class SimpleFont(FontBase):
         self.cfg = cfg
         self.dpi = cfg.get('dpi', 200)
         self.base_font_size = cfg.get('base_size', self.BASE_FONT_SIZE)
-        self.FONT_SIZE = self.base_font_size * (self.dpi / 200)
+        # Scale the font size more aggressively for high DPI screens
+        self.FONT_SIZE = self.base_font_size * (self.dpi / 200) ** 1.5
  
     def get_all_fonts(self, layout):
         for _, line in tqdm(enumerate(layout)):
@@ -34,7 +35,8 @@ class SimpleFont(FontBase):
         line_cnt = line.line_cnt if line.line_cnt and line.line_cnt > 0 else 1
 
         font_size = height / line_cnt
-        step = 6 * (self.dpi / 200)
+        # Allow fonts to grow more when DPI is high
+        step = 6 * (self.dpi / 200) ** 1.5
         if font_size > self.FONT_SIZE + step:
             font_size = self.FONT_SIZE + step
         elif font_size > self.FONT_SIZE:


### PR DESCRIPTION
## Summary
- scale fonts using a power of the DPI so they grow more at higher dpi settings
- widen the range of allowable font sizes using the same scaling

## Testing
- `pytest -q`